### PR TITLE
Integrate with snusnu/cookie

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 16
-total_score: 46
+total_score: 47

--- a/lib/response.rb
+++ b/lib/response.rb
@@ -16,6 +16,8 @@ class Response
 
   TEXT_PLAIN = 'text/plain; charset=UTF-8'.freeze
 
+  SET_COOKIE_HEADER = 'Set-Cookie'.freeze
+
   # Undefined response component
   #
   # A class to get nice #inspect behavior ootb
@@ -116,6 +118,36 @@ class Response
   #
   def with_headers(headers)
     self.class.new(status, headers, body)
+  end
+
+  # Return response with a new 'Set-Cookie' header
+  #
+  # @param [#to_s] header
+  #   An RFC6265 compliant Set-Cookie header
+  #
+  # @return [Response]
+  #   new response with headers set
+  #
+  # @example setting a new cookie
+  #
+  #   response = Response.new(200, {'Foo' => 'Baz'})
+  #   response = response.with_cookie('SID={"id": 11}; Domain=.foo.bar')
+  #   response.headers
+  #
+  #   # {
+  #   #   'Set-Cookie' => 'SID={"id": 11}; Domain=.foo.bar',
+  #   #   'Foo' => 'Baz'
+  #   # }
+  #
+  # @example deleting an existing cookie
+  #
+  #   response = Response.new(200, {})
+  #   header = 'SID=; Domain=.foo.bar; Expires=Thu, 01 Jan 1970 00:00:00 -0000'
+  #   response.with_cookie(header)
+  #
+  # @api public
+  def with_cookie(header)
+    merge_headers(SET_COOKIE_HEADER => header.to_s)
   end
 
   # Return response with merged headers

--- a/lib/response.rb
+++ b/lib/response.rb
@@ -213,7 +213,7 @@ class Response
   # @api public
   #
   def rack_array
-    [status.code, headers, body]
+    [status.code, headers, rack_body]
   end
   memoize :rack_array
 
@@ -294,6 +294,10 @@ private
   #
   def assert_valid
     fail InvalidError, "Not a valid response: #{inspect}" unless valid?
+  end
+
+  def rack_body
+    body.respond_to?(:each) ? body : Array(body)
   end
 end
 

--- a/spec/unit/response/with_cookie_spec.rb
+++ b/spec/unit/response/with_cookie_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Response, '#with_cookie' do
+  subject { object.with_cookie(cookie_object) }
+
+  let(:object)            { described_class.build(status, original_headers, body)  }
+  let(:status)            { Response::Status::OK }
+  let(:cookie_object)     { double('Cookie', to_s: set_cookie_header) }
+  let(:set_cookie_header) { double('set_cookie_header') }
+  let(:original_headers)  { { 'Foo' => 'Bar' } }
+
+  let(:status)  { double('Status')    }
+  let(:body)    { double('Body')      }
+
+  its(:status)  { should be(status) }
+  its(:body)    { should be(body)   }
+  its(:headers) { should eql('Foo' => 'Bar', 'Set-Cookie' => set_cookie_header) }
+
+  it_should_behave_like 'a functional command method'
+end


### PR DESCRIPTION
This eases generation of a response containing a `Set-Cookie` header. Initially it seemed to make sense to tightly integrate (i.e. depend on) `snusnu/cookie` but it turns out that really calling `#to_s` on whatever gets passed in as `Set-Cookie` header is enough.
